### PR TITLE
#13 Feat: 스프링 시큐리티 적용

### DIFF
--- a/src/main/java/com/example/barrier_free/domain/report/controller/ReportController.java
+++ b/src/main/java/com/example/barrier_free/domain/report/controller/ReportController.java
@@ -1,39 +1,39 @@
-package com.example.barrier_free.domain.report.controller;
-
-import java.util.Map;
-
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import com.example.barrier_free.domain.report.dto.ReportRequestDto;
-import com.example.barrier_free.domain.report.dto.VoteRequestDto;
-import com.example.barrier_free.domain.report.service.ReportService;
-import com.example.barrier_free.global.response.ApiResponse;
-import com.example.barrier_free.global.response.SuccessCode;
-
-import lombok.RequiredArgsConstructor;
-
-@RequiredArgsConstructor
-@RestController
-@RequestMapping("/reports")
-public class ReportController {
-
-	private final ReportService reportService;
-
-	@PostMapping
-	public ApiResponse<?> createReport(@RequestBody ReportRequestDto dto) {
-		Long id = reportService.createReport(dto);
-		return ApiResponse.success(SuccessCode.CREATED, Map.of("reportId", Long.valueOf(id)));
-	}
-
-	@PostMapping("/{reportId}/vote")
-	public ApiResponse<?> createVote(@RequestBody VoteRequestDto dto, @PathVariable Long reportId) {
-		Long id = reportService.createVote(dto, reportId);
-		return ApiResponse.success(SuccessCode.CREATED, Map.of("voteId", Long.valueOf(id)));
-
-	}
-
-}
+//package com.example.barrier_free.domain.report.controller;
+//
+//import java.util.Map;
+//
+//import org.springframework.web.bind.annotation.PathVariable;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RequestBody;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//import com.example.barrier_free.domain.report.dto.ReportRequestDto;
+//import com.example.barrier_free.domain.report.dto.VoteRequestDto;
+//import com.example.barrier_free.domain.report.service.ReportService;
+//import com.example.barrier_free.global.response.ApiResponse;
+//import com.example.barrier_free.global.response.SuccessCode;
+//
+//import lombok.RequiredArgsConstructor;
+//
+//@RequiredArgsConstructor
+//@RestController
+//@RequestMapping("/reports")
+//public class ReportController {
+//
+//	private final ReportService reportService;
+//
+//	@PostMapping
+//	public ApiResponse<?> createReport(@RequestBody ReportRequestDto dto) {
+//		Long id = reportService.createReport(dto);
+//		return ApiResponse.success(SuccessCode.CREATED, Map.of("reportId", Long.valueOf(id)));
+//	}
+//
+//	@PostMapping("/{reportId}/vote")
+//	public ApiResponse<?> createVote(@RequestBody VoteRequestDto dto, @PathVariable Long reportId) {
+//		Long id = reportService.createVote(dto, reportId);
+//		return ApiResponse.success(SuccessCode.CREATED, Map.of("voteId", Long.valueOf(id)));
+//
+//	}
+//
+//}

--- a/src/main/java/com/example/barrier_free/domain/report/service/ReportService.java
+++ b/src/main/java/com/example/barrier_free/domain/report/service/ReportService.java
@@ -1,72 +1,72 @@
-package com.example.barrier_free.domain.report.service;
-
-import java.util.List;
-
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.example.barrier_free.domain.facility.entity.Facility;
-import com.example.barrier_free.domain.facility.entity.ReportFacility;
-import com.example.barrier_free.domain.facility.repository.FacilityRepository;
-import com.example.barrier_free.domain.report.dto.ReportRequestDto;
-import com.example.barrier_free.domain.report.dto.VoteRequestDto;
-import com.example.barrier_free.domain.report.entity.Report;
-import com.example.barrier_free.domain.report.entity.Vote;
-import com.example.barrier_free.domain.report.mapper.ReportMapper;
-import com.example.barrier_free.domain.report.repository.ReportRepository;
-import com.example.barrier_free.domain.report.repository.VoteRepository;
-import com.example.barrier_free.domain.user.UserRepository;
-import com.example.barrier_free.domain.user.entity.User;
-import com.example.barrier_free.global.exception.CustomException;
-import com.example.barrier_free.global.response.ErrorCode;
-
-import lombok.RequiredArgsConstructor;
-
-@RequiredArgsConstructor
-@Service
-public class ReportService {
-
-	private final VoteRepository voteRepository;
-	private final ReportRepository reportRepository;
-	private final UserRepository userRepository;
-	private final FacilityRepository facilityRepository;
-
-	@Transactional
-	public Long createReport(ReportRequestDto dto) {
-		User user = userRepository.findById(dto.getUserId())
-			.orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
-
-		Report report = ReportMapper.toEntity(dto, user);
-
-		List<Facility> facilities = facilityRepository.findAllByIdIn(dto.getFacilities());
-
-		//요청한 편의시설이 진짜 편의시설에 있는지 확인
-		if (facilities.size() != dto.getFacilities().size()) {
-			throw new CustomException(ErrorCode.NOT_FOUND_FACILITY);
-		}
-
-		for (Facility facility : facilities) {
-			ReportFacility rf = new ReportFacility(facility, report);
-			report.addReportFacility(rf);
-		}
-
-		reportRepository.save(report);
-		return report.getId();
-	}
-
-	@Transactional
-	public long createVote(VoteRequestDto dto, Long reportId) {
-		User user = userRepository.findById(dto.getUserId())
-			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
-
-		Report report = reportRepository.findById(reportId)
-			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_REPORT));
-		if (voteRepository.existsByUserAndReport(user, report)) {
-			throw new CustomException(ErrorCode.ALREADY_VOTE);
-		}
-
-		Vote vote = report.createVote(dto.getVoteType(), user);
-		voteRepository.save(vote);
-		return vote.getId();
-	}
-}
+//package com.example.barrier_free.domain.report.service;
+//
+//import java.util.List;
+//
+//import org.springframework.stereotype.Service;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import com.example.barrier_free.domain.facility.entity.Facility;
+//import com.example.barrier_free.domain.facility.entity.ReportFacility;
+//import com.example.barrier_free.domain.facility.repository.FacilityRepository;
+//import com.example.barrier_free.domain.report.dto.ReportRequestDto;
+//import com.example.barrier_free.domain.report.dto.VoteRequestDto;
+//import com.example.barrier_free.domain.report.entity.Report;
+//import com.example.barrier_free.domain.report.entity.Vote;
+//import com.example.barrier_free.domain.report.mapper.ReportMapper;
+//import com.example.barrier_free.domain.report.repository.ReportRepository;
+//import com.example.barrier_free.domain.report.repository.VoteRepository;
+//import com.example.barrier_free.domain.user.UserRepository;
+//import com.example.barrier_free.domain.user.entity.User;
+//import com.example.barrier_free.global.exception.CustomException;
+//import com.example.barrier_free.global.response.ErrorCode;
+//
+//import lombok.RequiredArgsConstructor;
+//
+//@RequiredArgsConstructor
+//@Service
+//public class ReportService {
+//
+//	private final VoteRepository voteRepository;
+//	private final ReportRepository reportRepository;
+//	private final UserRepository userRepository;
+//	private final FacilityRepository facilityRepository;
+//
+//	@Transactional
+//	public Long createReport(ReportRequestDto dto) {
+//		User user = userRepository.findById(dto.getUserId())
+//			.orElseThrow(() -> new IllegalArgumentException("사용자 없음"));
+//
+//		Report report = ReportMapper.toEntity(dto, user);
+//
+//		List<Facility> facilities = facilityRepository.findAllByIdIn(dto.getFacilities());
+//
+//		//요청한 편의시설이 진짜 편의시설에 있는지 확인
+//		if (facilities.size() != dto.getFacilities().size()) {
+//			throw new CustomException(ErrorCode.NOT_FOUND_FACILITY);
+//		}
+//
+//		for (Facility facility : facilities) {
+//			ReportFacility rf = new ReportFacility(facility, report);
+//			report.addReportFacility(rf);
+//		}
+//
+//		reportRepository.save(report);
+//		return report.getId();
+//	}
+//
+//	@Transactional
+//	public long createVote(VoteRequestDto dto, Long reportId) {
+//		User user = userRepository.findById(dto.getUserId())
+//			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_USER));
+//
+//		Report report = reportRepository.findById(reportId)
+//			.orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_REPORT));
+//		if (voteRepository.existsByUserAndReport(user, report)) {
+//			throw new CustomException(ErrorCode.ALREADY_VOTE);
+//		}
+//
+//		Vote vote = report.createVote(dto.getVoteType(), user);
+//		voteRepository.save(vote);
+//		return vote.getId();
+//	}
+//}

--- a/src/main/java/com/example/barrier_free/domain/user/controller/AuthController.java
+++ b/src/main/java/com/example/barrier_free/domain/user/controller/AuthController.java
@@ -1,4 +1,28 @@
 package com.example.barrier_free.domain.user.controller;
 
+import com.example.barrier_free.domain.user.entity.User;
+import com.example.barrier_free.domain.user.service.UserService;
+import com.example.barrier_free.global.jwt.JwtUserUtils;
+import com.example.barrier_free.global.response.ApiResponse;
+import com.example.barrier_free.global.response.SuccessCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
 public class AuthController {
+
+    private final UserService userService;
+
+    // 내정보 테스트
+    // TODO: 삭제
+    @GetMapping("/me")
+    public ApiResponse<?> getMe() {
+        Long userId = JwtUserUtils.getCurrentUserId();
+        return ApiResponse.success(SuccessCode.OK, userService.getUser(userId));
+    }
 }

--- a/src/main/java/com/example/barrier_free/domain/user/controller/OAuthContoller.java
+++ b/src/main/java/com/example/barrier_free/domain/user/controller/OAuthContoller.java
@@ -13,12 +13,14 @@ import org.springframework.web.bind.annotation.*;
 import java.io.IOException;
 
 @RestController
-@RequestMapping("/auth/oauth")
+@RequestMapping("/oauth")
 @RequiredArgsConstructor
 public class OAuthContoller {
 
     @Value("${kakao.client_id}")
     private String client_id;
+
+
 
     @Value("${kakao.redirect_uri}")
     private String redirect_uri;
@@ -26,8 +28,9 @@ public class OAuthContoller {
     private final KakaoLoginService kakaoLoginService;
 
     // 1. 카카오 로그인 창으로 이동
-    // 로그인 성공 후 리다이렉트 URI로 인가 코드 보내줌
-    @GetMapping("/")
+    @GetMapping("/kakao")
+    @Operation(summary = "카카오 로그인 API",
+            description = "유저 정보, Access Token, Refresh Token 응답")
     public void redirectToKakao(HttpServletResponse response) throws IOException {
         String kakaoUrl = "https://kauth.kakao.com/oauth/authorize"
                 + "?client_id=" + client_id
@@ -36,12 +39,24 @@ public class OAuthContoller {
         response.sendRedirect(kakaoUrl);
     }
 
-    // 2. 인가코드 받아 로그인 진행
-    @GetMapping("/kakao")
-    @Operation(summary = "카카오 로그인 API",
+    // 2. 카카오 로그인 성공 후 리다이렉트 URI로 인가코드(code) 보내줌
+    @GetMapping("/kakao/success")
+    @Operation(summary = "카카오 로그인 성공 후 인가코드 발급 API",
             description = "유저 정보, Access Token, Refresh Token 응답")
-    public ApiResponse<?> loginWithKakao(@RequestParam String code) {
-        LoginResponse loginResponse =  kakaoLoginService.getKakaoAccessToken(code);
-        return ApiResponse.success(SuccessCode.LOGIN_SUCCESSFUL,loginResponse);
+    public void redirectToApp(@RequestParam String code, HttpServletResponse response) throws IOException {
+        // 앱 전용 딥링크로 리디렉션
+        String deepLink = "myapp://login-success?code=" + code;
+        response.sendRedirect(deepLink);
+
+        System.out.println("인가 코드: " + code);
+    }
+
+    // 3. 앱이 받은 인가코드를 백엔드에 보내면 → JWT 발급
+    @PostMapping("/token")
+    @Operation(summary = "인가코드로 JWT 발급",
+            description = "앱이 인가코드를 보내면 서버 자체 AccessToken/RefreshToken 발급")
+    public ApiResponse<?> exchangeCodeToToken(@RequestParam String code) {
+        LoginResponse loginResponse = kakaoLoginService.getKakaoAccessToken(code);
+        return ApiResponse.success(SuccessCode.LOGIN_SUCCESSFUL, loginResponse);
     }
 }

--- a/src/main/java/com/example/barrier_free/domain/user/controller/OAuthContoller.java
+++ b/src/main/java/com/example/barrier_free/domain/user/controller/OAuthContoller.java
@@ -20,8 +20,6 @@ public class OAuthContoller {
     @Value("${kakao.client_id}")
     private String client_id;
 
-
-
     @Value("${kakao.redirect_uri}")
     private String redirect_uri;
 
@@ -39,7 +37,7 @@ public class OAuthContoller {
         response.sendRedirect(kakaoUrl);
     }
 
-    // 2. 카카오 로그인 성공 후 리다이렉트 URI로 인가코드(code) 보내줌
+    // 2. 카카오 로그인 성공 후 리다이렉트 URI로 인가코드(code) 발급
     @GetMapping("/kakao/success")
     @Operation(summary = "카카오 로그인 성공 후 인가코드 발급 API",
             description = "유저 정보, Access Token, Refresh Token 응답")
@@ -51,7 +49,7 @@ public class OAuthContoller {
         System.out.println("인가 코드: " + code);
     }
 
-    // 3. 앱이 받은 인가코드를 백엔드에 보내면 → JWT 발급
+    // 3.인가코드로 JWT 발급
     @PostMapping("/token")
     @Operation(summary = "인가코드로 JWT 발급",
             description = "앱이 인가코드를 보내면 서버 자체 AccessToken/RefreshToken 발급")

--- a/src/main/java/com/example/barrier_free/domain/user/dto/LoginResponse.java
+++ b/src/main/java/com/example/barrier_free/domain/user/dto/LoginResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class LoginResponse {
-    private UserResponse userInfo;
+    private Long userId;
     private String accessToken;
     private String refreshToken;
 }

--- a/src/main/java/com/example/barrier_free/domain/user/service/KakaoLoginService.java
+++ b/src/main/java/com/example/barrier_free/domain/user/service/KakaoLoginService.java
@@ -68,8 +68,7 @@ public class KakaoLoginService {
         user.setTokens(accessToken, refreshToken);
         userRepository.save(user);
 
-        UserResponse userResponse = UserConverter.toUserResponse(user);
-        return new LoginResponse(userResponse, accessToken, refreshToken);
+        return new LoginResponse(userId, accessToken, refreshToken);
     }
 
     public JsonNode getKakaoUserInfo(String kAccessToken) {

--- a/src/main/java/com/example/barrier_free/domain/user/service/KakaoLoginService.java
+++ b/src/main/java/com/example/barrier_free/domain/user/service/KakaoLoginService.java
@@ -1,12 +1,10 @@
 package com.example.barrier_free.domain.user.service;
 
 import com.example.barrier_free.domain.user.UserRepository;
-import com.example.barrier_free.domain.user.converter.UserConverter;
 import com.example.barrier_free.domain.user.dto.LoginResponse;
-import com.example.barrier_free.domain.user.dto.UserResponse;
 import com.example.barrier_free.domain.user.entity.User;
 import com.example.barrier_free.domain.user.enums.SocialType;
-import com.example.barrier_free.global.auth.JwtManager;
+import com.example.barrier_free.global.jwt.JwtManager;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.netty.handler.codec.http.HttpHeaderValues;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/example/barrier_free/domain/user/service/UserService.java
+++ b/src/main/java/com/example/barrier_free/domain/user/service/UserService.java
@@ -1,0 +1,26 @@
+package com.example.barrier_free.domain.user.service;
+
+import com.example.barrier_free.domain.user.UserRepository;
+import com.example.barrier_free.domain.user.converter.UserConverter;
+import com.example.barrier_free.domain.user.dto.UserResponse;
+import com.example.barrier_free.domain.user.entity.User;
+import com.example.barrier_free.global.exception.CustomException;
+import com.example.barrier_free.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    // 내정보 테스트
+    // TODO: 삭제
+    public UserResponse getUser(Long userId) {
+        // 유저 초기화
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        return UserConverter.toUserResponse(user);
+    }
+}

--- a/src/main/java/com/example/barrier_free/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/barrier_free/global/config/SecurityConfig.java
@@ -1,5 +1,8 @@
 package com.example.barrier_free.global.config;
 
+import com.example.barrier_free.domain.user.UserRepository;
+import com.example.barrier_free.global.jwt.JwtAuthenticationFilter;
+import com.example.barrier_free.global.jwt.JwtManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,9 +13,10 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -21,12 +25,11 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests( auth -> auth
-                        .requestMatchers("/**")
-//                        .requestMatchers("/auth/**", "/swagger-ui/**", "/v3/api-docs/**")
+                        .requestMatchers("/oauth/**", "/swagger-ui/**", "/v3/api-docs/**")
                         .permitAll()
                         .anyRequest().authenticated()
-                );
-//                .addFilterBefore(new JwtAuthenticationFilter(jwtManager), UsernamePasswordAuthenticationFilter.class);
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/example/barrier_free/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/barrier_free/global/config/SecurityConfig.java
@@ -17,13 +17,15 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
 
-//        http.securityMatcher("/**")
-//                .csrf(csrf -> csrf.disable())
-//                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-//                .authorizeHttpRequests( auth -> auth
-//                        .requestMatchers("/auth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
-//                        .anyRequest().authenticated()
-//                )
+        http.securityMatcher("/**")
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests( auth -> auth
+                        .requestMatchers("/**")
+//                        .requestMatchers("/auth/**", "/swagger-ui/**", "/v3/api-docs/**")
+                        .permitAll()
+                        .anyRequest().authenticated()
+                );
 //                .addFilterBefore(new JwtAuthenticationFilter(jwtManager), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();

--- a/src/main/java/com/example/barrier_free/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/barrier_free/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package com.example.barrier_free.global.jwt;
+
+import com.example.barrier_free.domain.user.UserRepository;
+import com.example.barrier_free.domain.user.entity.User;
+import com.example.barrier_free.global.exception.CustomException;
+import com.example.barrier_free.global.response.ErrorCode;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtManager jwtManager;
+    private final UserRepository userRepository;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String requestURI = request.getRequestURI();
+
+        // 인증 제외할 경로는 필터 건너뜀
+        if (requestURI.startsWith("/oauth")
+                || requestURI.startsWith("/swagger-ui")
+                || requestURI.startsWith("/v3/api-docs")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            // 헤더에서 토큰 추출 후 유저 조회
+            String token = jwtManager.getToken(request);
+            if (token != null) {
+                Long userId = jwtManager.validateAccessToken(token);
+                userRepository.findById(userId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+                // 인증 객체 생성
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userId, null, List.of());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (CustomException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.JWT_UNKNOWN_ERROR); // 그외 예외
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/barrier_free/global/jwt/JwtManager.java
+++ b/src/main/java/com/example/barrier_free/global/jwt/JwtManager.java
@@ -1,8 +1,7 @@
-package com.example.barrier_free.global.auth;
+package com.example.barrier_free.global.jwt;
 
 import com.example.barrier_free.global.exception.CustomException;
 import com.example.barrier_free.global.response.ErrorCode;
-import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -11,26 +10,26 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class JwtManager {
 
-    private final JwtUtil jwtUtil;
+    private final JwtTokenUtils jwtTokenUtils;
 
     // accessToken 발급
     public String createAccessToken(Long userId) {
-        return jwtUtil.createAccessToken(userId);
+        return jwtTokenUtils.createAccessToken(userId);
     }
 
     // refreshToken 발급
     public String createRefreshToken(Long userId) {
-        return jwtUtil.createRefreshToken(userId);
+        return jwtTokenUtils.createRefreshToken(userId);
     }
 
     // accessToken 검증
     public Long validateAccessToken(String token) {
-        return jwtUtil.validateToken(token);
+        return jwtTokenUtils.validateToken(token);
     }
 
     // refreshToken 검증
     public Long validateRefreshToken(String token) {
-        return jwtUtil.validateToken(token);
+        return jwtTokenUtils.validateToken(token);
     }
 
     // Authorization 헤더에서 토큰 추출

--- a/src/main/java/com/example/barrier_free/global/jwt/JwtTokenUtils.java
+++ b/src/main/java/com/example/barrier_free/global/jwt/JwtTokenUtils.java
@@ -1,4 +1,4 @@
-package com.example.barrier_free.global.auth;
+package com.example.barrier_free.global.jwt;
 
 import com.example.barrier_free.global.exception.CustomException;
 import com.example.barrier_free.global.response.ErrorCode;
@@ -14,7 +14,7 @@ import java.util.Date;
 
 @Component
 @RequiredArgsConstructor
-public class JwtUtil {
+public class JwtTokenUtils {
 
     private final SecretKey key = Jwts.SIG.HS256.key().build();
 

--- a/src/main/java/com/example/barrier_free/global/jwt/JwtUserUtils.java
+++ b/src/main/java/com/example/barrier_free/global/jwt/JwtUserUtils.java
@@ -1,0 +1,10 @@
+package com.example.barrier_free.global.jwt;
+
+import org.springframework.security.core.context.SecurityContextHolder;
+
+public class JwtUserUtils {
+
+    public static Long getCurrentUserId() {
+        return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    }
+}


### PR DESCRIPTION
### ✨ 관련된 이슈
- 카카오 로그인 로직 변경 (1. 카카오 창 리다이렉트 > 2. 앱으로 카카오 인가코드 전달 > 3. 카카오 인가코드 받아서 카카오 로그인 진행 후 accesstoken 및 refreshtoken 발급)

### 🙌 작업 내용
- 카카오 로그인 로직 변경 (1. 카카오 창 리다이렉트 > 2. 앱으로 카카오 인가코드 전달 > 3. 카카오 인가코드 받아서 카카오 로그인 진행 후 accesstoken 및 refreshtoken 발급) 
- 로그인 응답형식 간단하게 수정 (유저 아이디 + 액세스토큰 + 리프레시토큰 만 반환)
- 스프링 시큐리티 적용

### 📸 스크린샷 (선택)
- http://localhost:8080/oauth/kakao로 접속
![image](https://github.com/user-attachments/assets/955aa7db-7b9f-4459-b837-4584e08b47ae) 
- 카카오 로그인 진행
![image](https://github.com/user-attachments/assets/5cc91acd-7758-4b96-8190-79fd127f20fa)
- 로그인 성공 후 실행 창에서 인가코드 확인
![image](https://github.com/user-attachments/assets/5d463626-15c0-45e5-9a2a-a1451c8eb5d7)
- 인가코드 복붙해서 POST /oauth/token에 쿼리변수에 넣기
![image](https://github.com/user-attachments/assets/92962594-dafd-422b-b974-be08b4bfe3c8)
![image](https://github.com/user-attachments/assets/357fbf2d-0ac3-4e1b-836f-0e311fe3a03b)
- 반환된 액세스토큰 복붙해서(현재 DB user에서도 복붙가능-추후 redis) 스웨거 아무 좌물쇠에 넣기 (Bearer 넣을 필요 X)
![image](https://github.com/user-attachments/assets/55e585f5-1dbc-4639-a7c4-7b6feabb46b4)
![image](https://github.com/user-attachments/assets/255ecd39-f07e-4273-92e4-e9188158cc1c)
- /auth/me에서 유저 정보 테스트 가능 (추후 삭제) - 이런식으로 인증이 필요한 api 스웨거에서 테스트 진행
![image](https://github.com/user-attachments/assets/47fa0bd1-7d1b-4217-99f7-11bb3e2fe736) 


- 코드 상에서는 로그인한 유저 정보 감지는
1. 컨트롤러에서 로그인한 유저 아이디 조회 `Long userId = JwtUserUtils.getCurrentUserId();`
![image](https://github.com/user-attachments/assets/fb9ea13a-14df-4ce8-bfa2-ccf76729ae92)
2. 유저 아이디로 **유저 초기화** 한 다음 진행하시면 됨 (초기화 하는 이유 = 유저 엔티티 역직렬화하는 리스트 많아서 터짐)
![image](https://github.com/user-attachments/assets/c81da8a2-e028-455f-9118-d2780a318f3a)
- 전반적으로 AuthContoller-UserService 참고
- 이해하기 어렵다면!! 이번주 금요일 회의때 설명!!!

### 🤔 리뷰 요구사항
- 프로젝트 실행시키면서 Report 부분에서 에러가 나는 바람에 ReportController-ReportService 모두 주석처리를 해버렸습니다. 
  **(그래서 바로 머지 X. 이전 pr 모두 develop에 올린 후에 제가 다시 로컬에서 돌려보고 머지할 예정)** 
- **application.yml 갱신함 (카카오 리다이렉트 부분) > 머지 후에 노션에 반영할 예정**
- 스프링 시큐리티 적용해서 현재 (/oauth/~ 부분 빼고는 다 헤더에 토큰이 필요함 > 스웨거 테스트시 좌물쇠에 토큰 넣기)
   만약 다른 api 테스트 하는데 불편하다면 일단 생략해두고 나중에 일괄적으로 적용할까요?